### PR TITLE
add request logger

### DIFF
--- a/lib/Mojo/WebSocketProxy/Dispatcher.pm
+++ b/lib/Mojo/WebSocketProxy/Dispatcher.pm
@@ -128,7 +128,7 @@ sub on_message {
     my $request_number = $c->app->stat->{cumulative_connection_requests}++;
     my $conn_number = $c->app->stat->{cumulative_client_connections};
     $req_storage->{cid} = sprintf("%s_%s:%s_%s:%s", $c->server_name, $$, $conn_number, $request_number, time);
-    $req_storage->{logger} = Binary::RequestLogger->new(req_storage => $req_storage);
+    $req_storage->{logger} = Mojo::WebSocketProxy::RequestLogger->new(req_storage => $req_storage);
     # We still want to run any hooks even for invalid requests.
     if (my $err = Mojo::WebSocketProxy::Parser::parse_req($c, $req_storage)) {
         $c->send({json => $err}, $req_storage);

--- a/lib/Mojo/WebSocketProxy/Dispatcher.pm
+++ b/lib/Mojo/WebSocketProxy/Dispatcher.pm
@@ -9,17 +9,19 @@ use Mojo::WebSocketProxy::Config;
 
 use Class::Method::Modifiers;
 
-use JSON::MaybeUTF8 qw(:v1);
+use JSON::MaybeUTF8    qw(:v1);
 use Unicode::Normalize ();
 use Future::Mojo 0.004;    # ->new_timeout
 use Future::Utils qw(fmap);
-use Scalar::Util qw(blessed);
+use Scalar::Util  qw(blessed);
 use Encode;
 use DataDog::DogStatsd::Helper qw(stats_inc);
 
 use constant TIMEOUT => $ENV{MOJO_WEBSOCKETPROXY_TIMEOUT} || 15;
 
-## VERSION
+use Mojo::WebSocketProxy::RequestLogger;
+
+our $VERSION = '0.14';     ## VERSION
 around 'send' => sub {
     my ($orig, $c, $api_response, $req_storage) = @_;
 
@@ -122,7 +124,11 @@ sub on_message {
 
     my $req_storage = {};
     $req_storage->{args} = $args;
-
+    
+    my $request_number = $c->app->stat->{cumulative_connection_requests}++;
+    my $conn_number = $c->app->stat->{cumulative_client_connections};
+    $req_storage->{cid} = sprintf("%s_%s:%s_%s:%s", $c->server_name, $$, $conn_number, $request_number, time);
+    $req_storage->{logger} = Binary::RequestLogger->new(req_storage => $req_storage);
     # We still want to run any hooks even for invalid requests.
     if (my $err = Mojo::WebSocketProxy::Parser::parse_req($c, $req_storage)) {
         $c->send({json => $err}, $req_storage);
@@ -293,8 +299,6 @@ Handle message - parse and dispatch request messages.
 Dispatching action and forward to RPC server. Note that all
 incoming JSON messages are first normalised using
 L<NFC|https://www.w3.org/International/articles/unicode-migration/#normalization>.
- 
-
 
 =head2 before_forward
 

--- a/lib/Mojo/WebSocketProxy/RequestLogger.pm
+++ b/lib/Mojo/WebSocketProxy/RequestLogger.pm
@@ -10,8 +10,13 @@ use UUID::Tiny;
 field $context; 
 
 our $handler = sub {
-    my ($context, $message) = @_;
-    $log->warn($message, $context);
+    my ($level, $message, $context, @params) = @_;
+    
+    if(scalar @params) {
+        return $log->$level($message, @params);
+    }
+
+    return $log->$level($message, $context);
 };
 
 sub set_handler {
@@ -23,8 +28,12 @@ BUILD {
     $context->{cid} = UUID::Tiny::create_UUID_as_string(UUID::Tiny::UUID_V4);
 }
 
-method infof ($message) {
-    $handler->($context, $message, 'infof');
+method infof ($message, @params) {
+    $handler->('infof', $message, $context, @params);
+}
+
+method info($message) {
+    $handler->('info', $message, $context);
 }
 
 1;

--- a/lib/Mojo/WebSocketProxy/RequestLogger.pm
+++ b/lib/Mojo/WebSocketProxy/RequestLogger.pm
@@ -24,7 +24,7 @@ BUILD {
 }
 
 method infof ($message) {
-    $handler->($context, $message);
+    $handler->($context, $message, 'infof');
 }
 
 1;

--- a/lib/Mojo/WebSocketProxy/RequestLogger.pm
+++ b/lib/Mojo/WebSocketProxy/RequestLogger.pm
@@ -5,13 +5,26 @@ class Mojo::WebSocketProxy::RequestLogger;
 use strict;
 use warnings;
 use Log::Any qw($log);
+use UUID::Tiny;
 
-field $req_storage: param;
+field $context; 
+
+our $handler = sub {
+    my ($context, $message) = @_;
+    $log->warn($message, $context);
+};
+
+sub set_handler {
+    my ($self, $h) = @_;
+    $handler = $h;
+} 
+
+BUILD {
+    $context->{cid} = UUID::Tiny::create_UUID_as_string(UUID::Tiny::UUID_V4);
+}
 
 method infof ($message) {
-    $log->adapter->set_context($req_storage->{cid});
-    $log->infof($message);
-    $log->adapter->clear_context;
+    $handler->($context, $message);
 }
 
 1;

--- a/lib/Mojo/WebSocketProxy/RequestLogger.pm
+++ b/lib/Mojo/WebSocketProxy/RequestLogger.pm
@@ -1,0 +1,17 @@
+use Object::Pad;
+
+class Mojo::WebSocketProxy::RequestLogger;
+
+use strict;
+use warnings;
+use Log::Any qw($log);
+
+field $req_storage: param;
+
+method infof ($message) {
+    $log->adapter->set_context($req_storage->{cid});
+    $log->infof($message);
+    $log->adapter->clear_context;
+}
+
+1;


### PR DESCRIPTION
We'll be setting the cid as soon as we receive a message, the `req_storage` object is there as a param on every function called in the WebSocket layer. Actually, Anywhere this object is not available means the function is not concerned with the request, and logs there should not attach a correlation ID.

Instead of just storing a cid in the request storage, we are storing a `RequestLogger` object. which is a wrapper for the `Log::Any` and will set the context for the adapter, log the message and clear out the context.

Usage:
```
 $req_storage->{logger}->infof("Timer started");
```

To override the default handler for `DERIV` adapter. in the bootstrap script we can provide our new context handler
```
use strict;
use warnings;
use Log::Any::Adapter 'DERIV',
    log_level => 'info',
    stderr    => 'json';
use Log::Any qw($log);

use Mojo::WebSocketProxy::RequestLogger;

Mojo::WebSocketProxy::RequestLogger->set_handler(
    sub {
        my ($level, $message, $context, @params) = @_;
        $log->adapter->set_context($context);
        $log->$level($message, @params);
        $log->adapter->clear_context;
    });

my $logger = Mojo::WebSocketProxy::RequestLogger->new;

$logger->infof("Hi %s", "there");
$logger->info("Hi with context");
``` 
